### PR TITLE
Reduce memory footprint

### DIFF
--- a/fcd/fcd.py
+++ b/fcd/fcd.py
@@ -78,7 +78,7 @@ def get_predictions(
                 .to("cpu")
                 .detach()
                 .numpy()
-                .astype(np.float32)  # this eliminates the memory leak and preserves the FCD values
+                .astype(np.float32)  # this reduces the memory footprint and preserves the FCD values
             )
 
     return np.row_stack(chemnet_activations)


### PR DESCRIPTION
### Context

I used the new version (1.2) of `fcd` to calculate the FCD of > 1M molecules.

### Issue

In this scenario, my corresponding python script crashed due to a large memory footprint (> 50 GB) on both `macOS` and `Linux`. This might be a local issue and depend on the specific `pytorch` version, among other things.

### Suggested resolution

I amended the code in two ways:

(1) Used a different context manager for inference; this does _not_ solve the issue, but was done in addition to ...
(2) Casting the inference result to `numpy float32` reduced the memory footprint. I am not sure why this works since the data type without the corresponding line is already `float32` and should be without any additional data, such as gradients.

I calculated the FCD for smaller molecule sets of size 100,000 to check whether the FCD value remains the same, which it did in my experiments.

In summary, I consider this to be a minor change which helps to alleviate memory problems, at least in certain configurations.
